### PR TITLE
Fix `exists` and `nested_fields` capabilities

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,36 @@
+name: check changelog
+
+on:
+  push:
+
+jobs:
+  check-changelog:
+    name: check changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: check changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.HASURA_BOT_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          # Check if the changelog is updated (or 'no-changelog-required' is added)
+          pull_request_number=$(gh pr view --json number -q .number || echo "")
+          if [ -z "$pull_request_number" ]; then
+            echo "This action is intended to be run on a pull request."
+            exit 0
+          fi
+          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$pull_request_number --jq '.labels.[].name')"
+          if echo "$labels" | grep -q "no-changelog-required"; then
+            echo "Changelog not required for this PR"
+            exit 0
+          elif git diff origin/main...HEAD --quiet "changelog.md" then
+            echo "Changelog has not been updated. Please update the changelog or add the label 'no-changelog-required' to the PR and rerun."
+            exit 1
+          else
+            echo "Thank you for updating the changelog ❤️❤️❤️"
+          fi

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed 
+
+### Fixed
+
+- Correctly output empty leaf capabilties for `exists` and `nested_fields`.
+
+
+<!-- end -->
+
+[Unreleased]: https://github.com/hasura/ndc-sdk-python/compare/v0.38...HEAD
+[v0.38]: https://github.com/hasura/ndc-sdk-kotlin/releases/tag/v0.39

--- a/hasura_ndc/function_connector.py
+++ b/hasura_ndc/function_connector.py
@@ -38,7 +38,9 @@ class FunctionConnector(Connector[Configuration, State]):
                 query=QueryCapabilities(
                     aggregates=LeafCapability(),
                     variables=LeafCapability(),
-                    explain=LeafCapability()
+                    explain=LeafCapability(),
+                    nested_fields=LeafCapability(),
+                    exists=LeafCapability()
                 ),
                 mutation=MutationCapabilities(
                     transactional=LeafCapability(),

--- a/hasura_ndc/models.py
+++ b/hasura_ndc/models.py
@@ -463,8 +463,8 @@ class QueryCapabilities(RootModel):
     aggregates: Optional['LeafCapability'] = None
     variables: Optional['LeafCapability'] = None
     explain: Optional['LeafCapability'] = None
-    nested_fields: Optional['NestedFieldCapabilities'] = None
-    exists: Optional['ExistsCapabilities'] = None
+    nested_fields: 'NestedFieldCapabilities' 
+    exists: 'ExistsCapabilities' 
 
 
 class MutationCapabilities(RootModel):


### PR DESCRIPTION
These are rejected by metadata build because it expects `{}` but gets `null`.

Also add a changelog and enforce changelog Github actions step.